### PR TITLE
Reorganised main JS module to have a nice init sequence

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -1,5 +1,5 @@
 import { samples, beatDetection } from './config.js';
-import { throttle, randomSwing } from './util.js';
+import { throttle, randomSwing, chooseRandomlyFrom } from './util.js';
 import { createAudioEngine } from './audio.js';
 import { startAnimating } from './network.js';
 
@@ -72,20 +72,16 @@ const initAudioSetup = context => new Promise((nextStep) => {
 
 const initPulse = async context => {
   const { socket, audioEngine, loadedSamples } = context;
-
-  const randomKick = () => {
-    let kicks = [loadedSamples.kick1, loadedSamples.kick2, loadedSamples.kick3, loadedSamples.kick4];
-    return kicks[Math.floor(Math.random() * 4)]
-  }
+  const kicks = [loadedSamples.kick1, loadedSamples.kick2, loadedSamples.kick3, loadedSamples.kick4];
 
   // this is how we can subscribe to various events from the server, and respond to them
   socket.on('pulse', data => {
     console.info('pulse', data);
 
-    audioEngine.playSample(randomKick(), 0 + randomSwing());
-    audioEngine.playSample(randomKick(), 0.25 + randomSwing());
-    audioEngine.playSample(randomKick(), 0.5 + randomSwing());
-    audioEngine.playSample(randomKick(), 0.75 + randomSwing());
+    audioEngine.playSample(chooseRandomlyFrom(kicks), 0 + randomSwing());
+    audioEngine.playSample(chooseRandomlyFrom(kicks), 0.25 + randomSwing());
+    audioEngine.playSample(chooseRandomlyFrom(kicks), 0.5 + randomSwing());
+    audioEngine.playSample(chooseRandomlyFrom(kicks), 0.75 + randomSwing());
 
     if(parseInt(data.my_cell) == 1){
       audioEngine.playSample(loadedSamples.rattle, 0 + randomSwing());

--- a/client/util.js
+++ b/client/util.js
@@ -32,3 +32,6 @@ export const throttle = (func, wait, options = {}) => {
     return result;
   };
 };
+
+// adding more human feel to the drumming
+export const randomSwing = () => (Math.random() - 0.5) / 70;

--- a/client/util.js
+++ b/client/util.js
@@ -35,3 +35,5 @@ export const throttle = (func, wait, options = {}) => {
 
 // adding more human feel to the drumming
 export const randomSwing = () => (Math.random() - 0.5) / 70;
+
+export const chooseRandomlyFrom = list => list[Math.floor(Math.random * list.length)];


### PR DESCRIPTION
each init step is an asynchronous function (or returns a Promise, which is the same thing)

after a step executes, it returns the context object, adding stuff to it if needed.

Only then does the next step execute, with the updated context object.

That way we can step through the 2 intro screens, and only start each part of the app when it can be started (e.g. samples won't be triggered by socket messages, until they've loaded)